### PR TITLE
Truthy and falsy reminder

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,12 @@ To compile the TypeScript source down to native JavaScript, run:
 npm run build
 ````
 
+You can also run the TypeScript compiler in watch mode with (start developing):
+
+```
+npm start
+```
+
 ### Running Tests
 
 To execute the test suite first compile the solution then run:

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ resolving boolean values such as:
 
 ## Credit
 
-Deep inspiration was taken from [this set of articles](https://ruslanspivak.com/lsbasi-part7/).  
+Deep inspiration was taken from [this set of articles](https://ruslanspivak.com/lsbasi-part7/).
 Here, the author gives details around the theory and practical implementation of creating a basic
 language processor and compiler.
 
@@ -53,6 +53,19 @@ Now you can bind and evaluate this expression against passed in objects:
 let record = { visible: false, admin: true };
 let visible =  Logic.evaluate('visible || admin', record); // resolves to true.
 ````
+
+### What is truthy and falsy?
+
+Logicality uses the same rules for deciding which values are true or false as JavaScript. As a reminder, JavaScript considers the following six things to be false:
+
+* false
+* undefined
+* null
+* NaN (not a number)
+* 0 (the number, not the string)
+* "" (the empty string)
+
+Everything evaluates to true.
 
 ### Plugging in Immutable.JS
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   ],
   "scripts": {
     "test": "mocha --reporter spec",
-    "build": "tsc"
+    "build": "tsc",
+    "start": "tsc -w"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,8 @@
     "chai": "^4.1.2",
     "mocha": "^5.2.0",
     "typescript": "^2.9.2"
+  },
+  "dependencies": {
+    "yarn": "^1.9.4"
   }
 }

--- a/test/logic_tests.js
+++ b/test/logic_tests.js
@@ -18,10 +18,10 @@ describe('Logic#evaluation', () => {
 
   it('should evaluate boolean-only expressions', () => {
     let tests = [
-      [ 'true',           null, true ],
+      [ 'true',           null, true  ],
       [ 'false',          null, false ],
       [ 'true && false',  null, false ],
-      [ 'true && true',   null, true ]
+      [ 'true && true',   null, true  ]
     ];
 
     tests.forEach(x => {
@@ -30,14 +30,34 @@ describe('Logic#evaluation', () => {
     });
   });
 
-  it('should evaluate and expressions', () => {
+  it('should evaluate using standard JavaScript truthy and falsy rules', () => {
+    let tests = [
+      [ 'a', { a: null },      false ],
+      [ 'a', { a: undefined }, false ],
+      [ 'a', { a: false },     false ],
+      [ 'a', { a: true },       true ],
+      [ 'a', { a: NaN },       false ],
+      [ 'a', { a: 0 },         false ],
+      [ 'a', { a: 1 },         true ],
+      [ 'a', { a: '' },        false ],
+      [ 'a', { a: ' ' },       true ],
+    ];
+
+    tests.forEach(x => {
+      let result = Logic.evaluate(x[0], x[1]);
+      expect(result).to.equal(x[2], `Failed on: ${x[0]} with a binding of ${JSON.stringify(x[1])}`);
+    });
+  });
+
+
+  it('should evaluate "and" expressions', () => {
     let tests = [
       [ 'a && b', null,                   false ],
       [ 'a && b', {},                     false ],
       [ 'a && b', { a: true },            false ],
       [ 'a && b', { a: true, b: false },  false ],
       [ 'a && b', { a: false, b: false }, false ],
-      [ 'a && b', { a: true, b: true },   true ]
+      [ 'a && b', { a: true, b: true },   true  ]
     ];
 
     tests.forEach(x => {
@@ -46,10 +66,10 @@ describe('Logic#evaluation', () => {
     });
   });
 
-  it('should evaluate and-or expressions', () => {
+  it('should evaluate "and-or" expressions', () => {
     let tests = [
-      [ 'a && b || c',    { a: false, b: false, c: true },  true ],
-      [ '(a && b) || c',  { a: false, b: false, c: true },  true ],
+      [ 'a && b || c',    { a: false, b: false, c: true },  true  ],
+      [ '(a && b) || c',  { a: false, b: false, c: true },  true  ],
       [ 'a || b && c',    { a: false, b: false, c: true },  false ],
       [ 'a || (b && c)',  { a: false, b: false, c: true },  false ],
       [ '(a || b) && c',  { a: false, b: false, c: true },  false ]
@@ -61,13 +81,13 @@ describe('Logic#evaluation', () => {
     });
   });
 
-  it('should evaluate not expressions', () => {
+  it('should evaluate "not" expressions', () => {
     let tests = [
-      [ '!a',         { a: false },            true ],
-      [ '!a && !b',   { a: false, b: false },  true ],
+      [ '!a',         { a: false },            true  ],
+      [ '!a && !b',   { a: false, b: false },  true  ],
       [ '!a && b',    { a: false, b: false },  false ],
       [ 'a && !b',    { a: false, b: false },  false ],
-      [ '!(a && b)',  { a: false, b: false },  true ]
+      [ '!(a && b)',  { a: false, b: false },  true  ]
     ];
 
     tests.forEach(x => {
@@ -78,10 +98,10 @@ describe('Logic#evaluation', () => {
 
   it('should treat question marks as a valid part of a value token', () => {
     let tests = [
-      [ 'a?',       { 'a?': true },             true ],
+      [ 'a?',       { 'a?': true },             true  ],
       [ '!a?',      { 'a?': true },             false ],
-      [ 'a? && b?', { 'a?': true, 'b?': true }, true ],
-      [ 'a && b?',  { a: true, 'b?': true },    true ]
+      [ 'a? && b?', { 'a?': true, 'b?': true }, true  ],
+      [ 'a && b?',  { a: true, 'b?': true },    true  ]
     ];
 
     tests.forEach(x => {

--- a/test/logic_tests.js
+++ b/test/logic_tests.js
@@ -7,12 +7,22 @@
 
 'use strict';
 
-var expect = require('chai').expect;
-var Logic = require('../dist/logic.js').Logic;
-var Logger = require('../dist/util/logger.js').Logger;
+const expect = require('chai').expect;
+const Logic = require('../dist/logic.js').Logic;
+const Logger = require('../dist/util/logger.js').Logger;
 
 //Uncomment this line if you want to output log data.
 //Logger.on();
+
+const testEvaluate = (tests) => {
+  tests.forEach((testData) => {
+    const [expression, bindings, expectedResult] = testData;
+
+    let result = Logic.evaluate(expression, bindings)
+    expect(result).to.equal(expectedResult,
+      `Failed on: '${expression}' with bindings of ${JSON.stringify(bindings)}`);
+  });
+};
 
 describe('Logic#evaluation', () => {
 
@@ -24,10 +34,7 @@ describe('Logic#evaluation', () => {
       [ 'true && true',   null, true  ]
     ];
 
-    tests.forEach(x => {
-      let result = Logic.evaluate(x[0], x[1]);
-      expect(result).to.equal(x[2], `Failed on: ${x[0]}`);
-    });
+    testEvaluate(tests);
   });
 
   it('should evaluate using standard JavaScript truthy and falsy rules', () => {
@@ -38,15 +45,12 @@ describe('Logic#evaluation', () => {
       [ 'a', { a: true },       true ],
       [ 'a', { a: NaN },       false ],
       [ 'a', { a: 0 },         false ],
-      [ 'a', { a: 1 },         true ],
+      [ 'a', { a: 1 },         true  ],
       [ 'a', { a: '' },        false ],
-      [ 'a', { a: ' ' },       true ],
+      [ 'a', { a: ' ' },       true  ],
     ];
 
-    tests.forEach(x => {
-      let result = Logic.evaluate(x[0], x[1]);
-      expect(result).to.equal(x[2], `Failed on: ${x[0]} with a binding of ${JSON.stringify(x[1])}`);
-    });
+    testEvaluate(tests);
   });
 
 
@@ -60,10 +64,7 @@ describe('Logic#evaluation', () => {
       [ 'a && b', { a: true, b: true },   true  ]
     ];
 
-    tests.forEach(x => {
-      let result = Logic.evaluate(x[0], x[1]);
-      expect(result).to.equal(x[2], `Failed on: ${x[0]}`);
-    });
+    testEvaluate(tests);
   });
 
   it('should evaluate "and-or" expressions', () => {
@@ -75,10 +76,7 @@ describe('Logic#evaluation', () => {
       [ '(a || b) && c',  { a: false, b: false, c: true },  false ]
     ];
 
-    tests.forEach(x => {
-      let result = Logic.evaluate(x[0], x[1]);
-      expect(result).to.equal(x[2], `Failed on: ${x[0]}`);
-    });
+    testEvaluate(tests);
   });
 
   it('should evaluate "not" expressions', () => {
@@ -90,10 +88,7 @@ describe('Logic#evaluation', () => {
       [ '!(a && b)',  { a: false, b: false },  true  ]
     ];
 
-    tests.forEach(x => {
-      let result = Logic.evaluate(x[0], x[1]);
-      expect(result).to.equal(x[2], `Failed on: ${x[0]}`);
-    });
+    testEvaluate(tests);
   });
 
   it('should treat question marks as a valid part of a value token', () => {
@@ -104,10 +99,7 @@ describe('Logic#evaluation', () => {
       [ 'a && b?',  { a: true, 'b?': true },    true  ]
     ];
 
-    tests.forEach(x => {
-      let result = Logic.evaluate(x[0], x[1]);
-      expect(result).to.equal(x[2], `Failed on: ${x[0]}`);
-    });
+    testEvaluate(tests);
   });
 
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -173,3 +173,7 @@ typescript@^2.9.2:
 wrappy@1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/wrappy/-/wrappy-1.0.2.tgz#b5243d8f3ec1aa35f1364605bc0d1036e30ab69f"
+
+yarn@^1.9.4:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/yarn/-/yarn-1.10.0.tgz#f7d81802586fa8b3b4bf3ac6fb493fbc6c29845c"


### PR DESCRIPTION
I was writing an expression parsed by logicality and wondered what exactly was going to evaluate to false. This adds some documentation and tests which reinforce current behavior.

Other bonus changes:
- Added a compiler watch command.
- Improved the diagnostics of the unit tests to include the binding when a test fails.
- Upgraded the yarn dependency (I got a warning when running yarn that it was out of date).